### PR TITLE
fix: handle engine error properly

### DIFF
--- a/src/Avast.js
+++ b/src/Avast.js
@@ -118,16 +118,16 @@ class Avast {
       if (this.resultMap.has(resolvedFilePath)) {
         break
       }
+
+      const scanError = this.resultMap.get('error')
+      if (scanError) {
+        this.resultMap.delete('error')
+        throw scanError
+      }
     }
 
     const scanResult = this.resultMap.get(resolvedFilePath)
     this.resultMap.delete(resolvedFilePath)
-    const scanError = this.resultMap.get('error')
-    this.resultMap.delete('error')
-
-    if (scanError) {
-      throw scanError
-    }
 
     if (!scanResult) {
       throw new Error('Scan Result Timeout')
@@ -148,6 +148,21 @@ class Avast {
       if (line.startsWith('451')) {
         this.logger.error('Engine error', line)
         this.resultMap.set('error', new Error('Engine error'))
+        return
+      }
+      if (line.startsWith('466')) {
+        this.logger.error('License error', line)
+        this.resultMap.set('error', new Error('License error'))
+        return
+      }
+      if (line.startsWith('501')) {
+        this.logger.error('Syntax error', line)
+        this.resultMap.set('error', new Error('Syntax error'))
+        return
+      }
+      if (line.startsWith('520')) {
+        this.logger.error('URL blocked', line)
+        this.resultMap.set('error', new Error('URL blocked'))
         return
       }
 

--- a/src/Avast.js
+++ b/src/Avast.js
@@ -142,12 +142,11 @@ class Avast {
   async _processData (data) {
     const lines = data.toString().split(/\r\n/gm)
     for (const line of lines) {
-      const args = line.split(/\t/gm)
-      const fileName = args[0].split(' ')[1]
-      const rootFileName = fileName.split('|>')[0]
-
       // Engine Error (451 Engine Error) <- message
       if (line.startsWith('451')) {
+        const args = line.split(/\t/gm)
+        const fileName = args[0].split(' ')[1]
+        const rootFileName =  fileName.split('|>')[0]
         this.logger.error('Engine error', line)
         this.resultMap.set(rootFileName, { error: true, Error: new Error('Engine error') })
         return
@@ -158,7 +157,10 @@ class Avast {
       }
 
       if (line.startsWith('SCAN')) {
+        const args = line.split(/\t/gm)
+        const fileName = args[0].split(' ')[1]
         // This is used for archives
+        const rootFileName =  fileName.split('|>')[0]
         this.history.push(line)
 
         if (!this.resultMap.get(rootFileName)) {

--- a/src/Avast.js
+++ b/src/Avast.js
@@ -122,13 +122,15 @@ class Avast {
 
     const scanResult = this.resultMap.get(resolvedFilePath)
     this.resultMap.delete(resolvedFilePath)
+    const scanError = this.resultMap.get('error')
+    this.resultMap.delete('error')
+
+    if (scanError) {
+      throw scanError
+    }
 
     if (!scanResult) {
       throw new Error('Scan Result Timeout')
-    }
-
-    if (scanResult.error) {
-      throw scanResult.Error
     }
 
     const isSafe = !scanResult.is_infected && !scanResult.is_password_protected && !scanResult.permission_denied
@@ -144,11 +146,8 @@ class Avast {
     for (const line of lines) {
       // Engine Error (451 Engine Error) <- message
       if (line.startsWith('451')) {
-        const args = line.split(/\t/gm)
-        const fileName = args[0].split(' ')[1]
-        const rootFileName = fileName.split('|>')[0]
         this.logger.error('Engine error', line)
-        this.resultMap.set(rootFileName, { error: true, Error: new Error('Engine error') })
+        this.resultMap.set('error', new Error('Engine error'))
         return
       }
 

--- a/src/Avast.js
+++ b/src/Avast.js
@@ -142,6 +142,10 @@ class Avast {
   async _processData (data) {
     const lines = data.toString().split(/\r\n/gm)
     for (const line of lines) {
+      const args = line.split(/\t/gm)
+      const fileName = args[0].split(' ')[1]
+      const rootFileName = fileName.split('|>')[0]
+
       // Engine Error (451 Engine Error) <- message
       if (line.startsWith('451')) {
         this.logger.error('Engine error', line)
@@ -154,10 +158,7 @@ class Avast {
       }
 
       if (line.startsWith('SCAN')) {
-        const args = line.split(/\t/gm)
-        const fileName = args[0].split(' ')[1]
         // This is used for archives
-        const rootFileName = fileName.split('|>')[0]
         this.history.push(line)
 
         if (!this.resultMap.get(rootFileName)) {

--- a/src/Avast.js
+++ b/src/Avast.js
@@ -146,7 +146,7 @@ class Avast {
       if (line.startsWith('451')) {
         const args = line.split(/\t/gm)
         const fileName = args[0].split(' ')[1]
-        const rootFileName =  fileName.split('|>')[0]
+        const rootFileName = fileName.split('|>')[0]
         this.logger.error('Engine error', line)
         this.resultMap.set(rootFileName, { error: true, Error: new Error('Engine error') })
         return
@@ -160,7 +160,7 @@ class Avast {
         const args = line.split(/\t/gm)
         const fileName = args[0].split(' ')[1]
         // This is used for archives
-        const rootFileName =  fileName.split('|>')[0]
+        const rootFileName = fileName.split('|>')[0]
         this.history.push(line)
 
         if (!this.resultMap.get(rootFileName)) {

--- a/src/Avast.js
+++ b/src/Avast.js
@@ -127,6 +127,10 @@ class Avast {
       throw new Error('Scan Result Timeout')
     }
 
+    if (scanResult.error) {
+      throw scanResult.Error
+    }
+
     const isSafe = !scanResult.is_infected && !scanResult.is_password_protected && !scanResult.permission_denied
     return {
       history: [...this.history],
@@ -141,7 +145,8 @@ class Avast {
       // Engine Error (451 Engine Error) <- message
       if (line.startsWith('451')) {
         this.logger.error('Engine error', line)
-        throw new Error('Engine error')
+        this.resultMap.set(rootFileName, { error: true, Error: new Error('Engine error') })
+        return
       }
 
       if (line.startsWith('VPS')) {


### PR DESCRIPTION
In case of Engine Error, the library was creating an unhandledPromiseRejection, since the error originated in _processData which inside of an even listener, and it didn't properly propagate.